### PR TITLE
Added Go BG meetup release party

### DIFF
--- a/events/2017-08-go1.9-release-party.md
+++ b/events/2017-08-go1.9-release-party.md
@@ -32,5 +32,5 @@ Please, keep these in chronological order.
 |  Edmonton      |  Canada      |  Americas    |  August 28th 6:30PM |  [meetup](https://www.meetup.com/startupedmonton/events/242022523/)       |
 |  Berlin        |  Germany     |  Europe      |  August 30th 7PM   |  [meetup](https://www.meetup.com/golang-users-berlin/events/242617466/) |
 |  Frankfurt     |  Germany     |  Europe      |  September 07th 6:30PM |  [meetup](https://www.meetup.com/de-DE/gophers-frm/events/242325815/) |
-
+|  Sofia     |  Bulgaria     |  Europe      |  September 12th 6:45PM |  [meetup](https://www.meetup.com/Golang-Bulgaria/events/242639745/) |
 _¹ Continents: Antarctica, Africa, Americas, Asia, Europe, Oceania._


### PR DESCRIPTION
Added info for the Go 1.9 release party of the Bulgarian Go meetup in Sofia on the 12th of September.